### PR TITLE
logout example

### DIFF
--- a/001-oidc-local-test/openid_connect.js
+++ b/001-oidc-local-test/openid_connect.js
@@ -275,31 +275,27 @@ function validateIdToken(r) {
     }
 }
 
-//
-// Default RP-Initiated or Custom Logout w/ OP.
-// 
-// - An RP requests that the OP log out the end-user by redirecting the
-//   end-user's User Agent to the OP's Logout endpoint.
-// - https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
-// - https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RedirectionAfterLogout
-//
+// Default RP-Initiated or Custom Logout w/ OP as per:
+//  https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
+//  https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RedirectionAfterLogout
+// An RP requests that the OP log out the end-user by redirecting the end-user's
+// User Agent to the OP's Logout endpoint.
 function logout(r) {
     r.log("OIDC logout for " + r.variables.cookie_auth_token);
-    var idToken = r.variables.session_jwt;
-    var queryParams = '?post_logout_redirect_uri=' + 
-                      r.variables.redirect_base + 
-                      r.variables.oidc_logout_redirect +
-                      '&id_token_hint=' + idToken;
-    if (r.variables.oidc_logout_query_params_option == REPLACE_PARAMS) {
+    var queryParams = '';
+    if (r.variables.oidc_logout_query_params) {
         queryParams = '?' + r.variables.oidc_logout_query_params;
-    } else if (r.variables.oidc_logout_query_params_option == EXTRA_PARAMS) {
-        queryParams += '&' + r.variables.oidc_logout_query_params;
-    } 
+    }
     r.variables.request_id    = '-';
     r.variables.session_jwt   = '-';
     r.variables.access_token  = '-';
     r.variables.refresh_token = '-';
     r.return(302, r.variables.oidc_logout_endpoint + queryParams);
+}
+
+// Redirect URI after logged-out from the OP.
+function redirectPostLogout(r) {
+    r.return(302, r.variables.oidc_logout_landing_page);
 }
 
 function getQueryParamsAuthZ(r) {
@@ -351,17 +347,6 @@ function idpClientAuth(r) {
 function redirectPostLogin(r) {
     if (r.variables.oidc_landing_page) {
         r.return(302, r.variables.oidc_landing_page);
-    } else {
-        r.return(302, r.variables.redirect_base + r.variables.cookie_auth_redir);
-    }
-}
-
-//
-// Redirect URI after logged-out from the OP.
-//
-function redirectPostLogout(r) {
-    if (r.variables.post_logout_return_uri) {
-        r.return(302, r.variables.post_logout_return_uri);
     } else {
         r.return(302, r.variables.redirect_base + r.variables.cookie_auth_redir);
     }

--- a/001-oidc-local-test/openid_connect.server_conf
+++ b/001-oidc-local-test/openid_connect.server_conf
@@ -97,23 +97,22 @@
     }
 
     location = /_logout {
-        # This location is a RP's callback URI that is the default value of 
-        # $oidc_logout_redirect which is called by OP after successful logout.
+        # This location is a RP's callback URI which is called by the IdP after
+        # successful logout from the IdP by calling $oidc_logout_endpoint.
 
         # Clean cookies
         add_header Set-Cookie "auth_token=; $oidc_cookie_flags"; # Send empty cookie
         add_header Set-Cookie "auth_redir=; $oidc_cookie_flags"; # Erase original cookie
         add_header Set-Cookie "auth_nonce=; $oidc_cookie_flags"; 
 
-        # Enable one of the following examples.
-
-        # Example 1. Built-in, simple logout page
-        #default_type text/plain;
-        #return 200 "Logged out\n";
-
-        # Example 2. Redirect to either the landing page or custom logout page
-        #            using the map of $post_logout_return_uri.
         js_content oidc.redirectPostLogout;
+    }
+
+    location = /logout_page {
+        # This location is a default value of $oidc_logout_landing_page as a 
+        # Built-in, simple logout page in case it wasn't configured.
+        default_type text/plain;
+        return 200 "Logged out\n";
     }
 
     location @oidc_error {

--- a/001-oidc-local-test/openid_connect_configuration.conf
+++ b/001-oidc-local-test/openid_connect_configuration.conf
@@ -38,21 +38,12 @@ map $host $oidc_logout_endpoint {
     default "http://host.docker.internal:8080/auth/realms/master/protocol/openid-connect/logout";
 }
 
-map $host $oidc_logout_query_params_option {
-    # 0: default query params for the RP-initiated logout
-    # 1: extra query params is added after the default query params
-    # 2: replace default query params with custom query params
-    default 0;
-}
-
 map $host $oidc_logout_query_params {
-    # Each IdP use different query params of the $oidc_logout_endpoint. For
-    # example, The Amazon Cognito requires `client_id` and `logout_uri`. The
-    # Auth0 requires `client_id` and `returnTo`. If this option is empty, then
-    # `post_logout_redirect_uri` and `id_token_hint` are used as default query
-    # params, and the AzureAD/Okta/Keycloak/OneLogin/PingIdentity use them.
-    default "";
-    # www.example.com "client_id=$oidc_client&logout_uri=$redirect_base/_logout";
+    # Each IdP may use different query params of the $oidc_logout_endpoint. For
+    # example, Amazon Cognito requires `client_id` and `logout_uri`, and Auth0
+    # requires `client_id` and `returnTo` instead of the default query params.
+    default "post_logout_redirect_uri=$redirect_base/_logout&id_token_hint=$session_jwt";
+    #www.example.com "client_id=$oidc_client&logout_uri=$redirect_base/_logout";
 }
 
 map $host $oidc_userinfo_endpoint {
@@ -93,26 +84,10 @@ map $host $oidc_landing_page {
     www.example.com $redirect_base;
 }
 
-map $host $oidc_logout_redirect {
-    # This is a RP's callback URI which is called by OP after successful logout.
-    default "/_logout"; # Built-in, simple logout page
-}
-
-map $host $post_logout_return_uri {
-    # Where to send browser after the RP requests /logout to the OP, and after
-    # the RP (/_logout) is called by the OP and cleans cookies. The following
-    # If this is empty, then the RP redirects to $request_uri.
-
-    default "";
-
-    # Edit if you want to redirect to the landing page
-    www.example.com $oidc_landing_page;
-
-    # Edit if you want to redirect to a custom logout page
-    #www.example.com $redirect_base/signout;
-
-    # Edit if you want to redirect to an another complete URL
-    #www.example.com https://www.nginx.com;
+map $host $oidc_logout_landing_page {
+    # Where to redirect browser after successful logout from the IdP.
+    default "$redirect_base/logout_page"; # Built-in, simple logout page
+    www.example.com $redirect_base;
 }
 
 map $host $oidc_hmac_key {


### PR DESCRIPTION
- Add `$oidc_logout_landing_page`
- Revise `$oidc_logout_query_params`
- Add `/logout_page` as a Builtin, simple logout page